### PR TITLE
chore: add `use_ssh_args` option to sync scripts task

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -269,6 +269,7 @@
     recursive: yes
     delete: yes
     mode: push
+    use_ssh_args: yes
     src: "files/groovy/"
     dest: "{{ nexus_data_dir }}/groovy-raw-scripts/new/"
 


### PR DESCRIPTION
# Description
cf. issue https://github.com/ansible-ThoTeam/nexus3-oss/issues/58

Enable option `use_ssh_args` of `synchronize` module is needed to load ssh arguments.